### PR TITLE
Update player-service-backend to use the latest minor version release

### DIFF
--- a/player-service-backend/pom.xml
+++ b/player-service-backend/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>io.github.ollama4j</groupId>
             <artifactId>ollama4j</artifactId>
-            <version>1.0.79</version>
+            <version>1.0.100</version>
         </dependency>
     </dependencies>
 

--- a/player-service-backend/src/main/java/com/app/playerservicejava/controller/chat/ChatController.java
+++ b/player-service-backend/src/main/java/com/app/playerservicejava/controller/chat/ChatController.java
@@ -2,7 +2,7 @@ package com.app.playerservicejava.controller.chat;
 
 import com.app.playerservicejava.service.chat.ChatClientService;
 import io.github.ollama4j.exceptions.OllamaBaseException;
-import io.github.ollama4j.models.Model;
+import io.github.ollama4j.models.response.Model; // ollama 1.0.80+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,7 +33,11 @@ public class ChatController {
 
     @GetMapping("/list-models")
     public ResponseEntity<List<Model>> listModels() throws OllamaBaseException, IOException, URISyntaxException, InterruptedException {
-        List<Model> models = chatClientService.listModels();
-        return ResponseEntity.ok(models);
+        // try {
+          List<Model> models = chatClientService.listModels();
+          return ResponseEntity.ok(models);
+        // } catch(Exception e) {
+        //   throw e;
+        // }
     }
 }

--- a/player-service-backend/src/main/java/com/app/playerservicejava/service/chat/ChatClientService.java
+++ b/player-service-backend/src/main/java/com/app/playerservicejava/service/chat/ChatClientService.java
@@ -2,8 +2,8 @@ package com.app.playerservicejava.service.chat;
 
 import io.github.ollama4j.OllamaAPI;
 import io.github.ollama4j.exceptions.OllamaBaseException;
-import io.github.ollama4j.models.Model;
-import io.github.ollama4j.models.OllamaResult;
+import io.github.ollama4j.models.response.Model; // ollama 1.0.80+
+import io.github.ollama4j.models.response.OllamaResult; // ollama 1.0.80+
 import io.github.ollama4j.types.OllamaModelType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
PROBLEM

The 1.0.79 version of ollama4j appears to have a typing bug whereby a new field, "capabilities", was added to a model, but not updated in all the places where it is used by the listModels method.

SOLUTION

Move the ollama4j dependency to the last compatible minor version, 1.0.100.

BEFORE

<img width="1693" height="743" alt="Screenshot 2026-08-04 105233" src="https://github.com/user-attachments/assets/d8284948-8c2c-4817-b4c9-da360991edcb" />

AFTER

<img width="1702" height="737" alt="Screenshot 2026-08-04 105444" src="https://github.com/user-attachments/assets/801a1435-7e14-4fb5-ac90-17825a007273" />
